### PR TITLE
Use enums for the different options

### DIFF
--- a/code/MicroDataTeachingVars.py
+++ b/code/MicroDataTeachingVars.py
@@ -15,22 +15,28 @@ class OptionEnum(Enum):
     def parse(cls, encoded):
         """Parses the encoded key into a enum variant"""
         for m in cls:
-            if encoded == m.value[0]:
+            if encoded == m.key():
                 return m
         raise KeyError(str(encoded) + " is not a valid key for " + str(cls))
 
     @classmethod
     def keys(cls):
         """Returns a list of the valid keys for this option"""
-        return [m.value[0] for m in cls]
+        return [m.key() for m in cls]
+
+    def key(self):
+        return self.value[0]
+
+    def desc(self):
+        return self.value[1]
 
     def __str__(self):
         """Returns a human readable description of what this enum signified"""
-        return self.value[1]
+        return self.desc()
 
     def __repr__(self):
         """Returns a representation of this enum with both value and type information"""
-        return f"<{self.__class__.__name__}: {self.value[1]}>" 
+        return f"<{self.__class__.__name__}: {self.key()} -> {self.name}>"
 
 
 class RegionOptions(OptionEnum):
@@ -59,9 +65,9 @@ class FamilyCompositionOptions(OptionEnum):
     LONE_FATHER   = (4, "Lone parent family (male head)")
     LONE_MOTHER   = (5, "Lone parent family (female head)")
     OTHER         = (6, "Other related family")
-    NO_CODE       = (-9,"No code required (Resident of communal establishment, \
-                         students or schoolchildren living away during \
-                         term-time, or a short-term resident")
+    NO_CODE       = (-9,"No code required (Resident of communal establishment, "
+                         "students or schoolchildren living away during "
+                         "term-time, or a short-term resident")
 
 
 class PopulationBaseOptions(OptionEnum):
@@ -87,15 +93,15 @@ class AgeOptions(OptionEnum):
 
 
 class MaritalStatusOptions(OptionEnum):
-    SINGLE    = (1, "Single (never married or never registered in a \
-                     same-sex civil partnership)")
+    SINGLE    = (1, "Single (never married or never registered in a "
+                     "same-sex civil partnership)")
     MARRIED   = (2, "Married or in a registered same-sex civil partnership")
-    SEPARATED = (3, "Separated but still legally marrried or seperated \
-                     but still legally in a same-sex civil partnership")
-    DIVORCED  = (4, "Divorced or formely in a same-sex civil partnership \
-                     which is now legally dissolved")
-    WIDOWED   = (5, "Widowed or surviving partner from a same-sex \
-                     civil partnership")
+    SEPARATED = (3, "Separated but still legally marrried or seperated "
+                    "but still legally in a same-sex civil partnership")
+    DIVORCED  = (4, "Divorced or formely in a same-sex civil partnership "
+                    "which is now legally dissolved")
+    WIDOWED   = (5, "Widowed or surviving partner from a same-sex"
+                    "civil partnership")
 
 
 class StudentOptions(OptionEnum):
@@ -106,8 +112,8 @@ class StudentOptions(OptionEnum):
 class CountryOfBirthOptions(OptionEnum):
     UK      = (1, "UK")
     NON_UK  = (2, "Non UK")
-    NO_CODE = (-9,"No Code required (Students or schoolchildren living away \
-                   during term-time") 
+    NO_CODE = (-9,"No Code required (Students or schoolchildren living away "
+                   "during term-time")
 
 
 class HealthOptions(OptionEnum):
@@ -116,8 +122,8 @@ class HealthOptions(OptionEnum):
     FAIR      = (3, "Fair health")
     BAD       = (4, "Bad health")
     VERY_BAD  = (5, "Very bad health")
-    NO_CODE   = (-9,"No code required (Students or schoolchildren living away \
-                     during term-time")
+    NO_CODE   = (-9,"No code required (Students or schoolchildren living away "
+                     "during term-time")
 
 
 class EthnicityOptions(OptionEnum):
@@ -126,8 +132,8 @@ class EthnicityOptions(OptionEnum):
     ASIAN   = (3, "Asian or Asian British")
     BLACK   = (4, "Black or Black British")
     OTHER   = (5, "Chinese or Other ethnic group")
-    NO_CODE = (-9,"No code required (Not resident in England or Wales, \
-                   students or schoolchildren living away during term time")
+    NO_CODE = (-9,"No code required (Not resident in England or Wales, "
+                   "students or schoolchildren living away during term time")
 
 class ReligionOptions(OptionEnum):
     NONE       = (1, "No religion")
@@ -139,9 +145,9 @@ class ReligionOptions(OptionEnum):
     SIKH       = (7, "Sikh")
     OTHER      = (8, "Other religion")
     NOT_STATED = (9, "Not stated")
-    NO_CODE    = (-9,"No code required (Not resident in England or \
-                      Wales, students or schoolchildren living away \
-                      during term-time)")
+    NO_CODE    = (-9,"No code required (Not resident in England or "
+                      "Wales, students or schoolchildren living away "
+                      "during term-time)")
 
 
 class EconomicActivityOptions(OptionEnum):
@@ -154,8 +160,8 @@ class EconomicActivityOptions(OptionEnum):
     CARING            = (7, "Economically inactive: Looking after home or family")
     SICK_OR_DISABLED  = (8, "Economically inactive: Long-term sick or disabled")
     OTHER             = (9, "Economically inactive: Other")
-    NO_CODE           = (-9,"No code required (Aged under 16 or students \
-                             or schoolchildren living away during term-time)")
+    NO_CODE           = (-9,"No code required (Aged under 16 or students "
+                             "or schoolchildren living away during term-time)")
 
 
 class OccupationOptions(OptionEnum):
@@ -168,57 +174,57 @@ class OccupationOptions(OptionEnum):
     SALES_SERVICE          = (7, "Sales and Customer Service Occupations")
     PLANT_OPERATIVE        = (8, "Process, Plant and Machine Operatives")
     ELEMENTARY             = (9, "Elementary Occupations")
-    NO_CODE                = (-9,"No code required (People aged under 16, \
-                                  people who have never worked and students or \
-                                  schoolchildren living away during term-time)")
+    NO_CODE                = (-9,"No code required (People aged under 16, "
+                                  "people who have never worked and students or "
+                                  "schoolchildren living away during term-time)")
 
 
 class IndustryOptions(OptionEnum):
     AGRICULTURE                 = (1, "Agriculture, forestry and fishing")
-    ESSENTIALS                  = (2, "Mining and quarrying; Manufacturing; \
-                                       Electricity, gas, steam and air conditioning \
-                                       system; Water supply")
+    ESSENTIALS                  = (2, "Mining and quarrying; Manufacturing; "
+                                       "Electricity, gas, steam and air conditioning "
+                                       "system; Water supply")
     CONSTRUCTION                = (3, "Construction")
-    TRADE_AND_MOTOR             = (4, "Wholesale and retail trade; Repair of motor \
-                                       vehicles and motorcycles")
+    TRADE_AND_MOTOR             = (4, "Wholesale and retail trade; Repair of motor "
+                                       "vehicles and motorcycles")
     ACCOMODATION_AND_FOOD       = (5, "Accomodation and food service activities")
-    TRANSPORT_AND_COMMUNICATION = (6, "Transport and storage; \
-                                       Information and communication")
+    TRANSPORT_AND_COMMUNICATION = (6, "Transport and storage; "
+                                       "Information and communication")
     FINANCIAL                   = (7, "Financial and insurance activities; Intermediation")
-    REAL_ESTATE_TECHNICAL_ADMIN = (8, "Real estate activities; Professional, \
-                                       scientific and technical activities; \
-                                       Administrative and \
-                                       support service activities")
+    REAL_ESTATE_TECHNICAL_ADMIN = (8, "Real estate activities; Professional, "
+                                       "scientific and technical activities; "
+                                       "Administrative and "
+                                       "support service activities")
     EDUCATION                   = (9, "Education")
     HEALTH_AND_SOCIAL_WORK      = (10,"Human health and social work activities")
-    PUBLIC_ADMIN_DEFENSE_SOCIAL = (11,"Public administration and defence; \
-                                       compulsory social security")
-    OTHER                       = (12,"Other community, social and personal \
-                                       service activities; Private households \
-                                       employing domestic staff; Extra-territorial \
-                                       organisations and bodies")
-    NO_CODE                     = (-9,"No code required (People aged under 16, \
-                                       people who have never worked, and students or \
-                                       schoolchildren living away during term-time)")
+    PUBLIC_ADMIN_DEFENSE_SOCIAL = (11,"Public administration and defence; "
+                                       "compulsory social security")
+    OTHER                       = (12,"Other community, social and personal "
+                                       "service activities; Private households "
+                                       "employing domestic staff; Extra-territorial "
+                                       "organisations and bodies")
+    NO_CODE                     = (-9,"No code required (People aged under 16, "
+                                       "people who have never worked, and students or "
+                                       "schoolchildren living away during term-time)")
 
 class HoursWorkedPerWeekOptions(OptionEnum):
     PART_TIME_LOW  = (1, "Part-time: 15 or less hours worked")
     PART_TIME_HIGH = (2, "Part-time: 16 to 30 hours worked")
     FULL_TIME_LOW  = (3, "Full-time: 31 to 48 hours worked")
     FULL_TIME_HIGH = (4, "Full-time: 49 or more hours worked")
-    NO_CODE        = (-9,"No code required (People aged under 16, \
-                          people not working, and students or schoolchildren \
-                          living away during term-time)")
+    NO_CODE        = (-9,"No code required (People aged under 16, "
+                          "people not working, and students or schoolchildren "
+                          "living away during term-time)")
 
 class SocialGradeOptions(OptionEnum):
     AB = (1, "AB")
     C1 = (2, "C1")
     C2 = (3, "C2")
     DE = (4, "DE")
-    NO_CODE = (-9, "No code required (People aged under 16, \
-                    people resident in communal establishments, and \
-                    students or schoolchildren living away during term- \
-                    time)")
+    NO_CODE = (-9, "No code required (People aged under 16, "
+                    "people resident in communal establishments, and "
+                    "students or schoolchildren living away during term- "
+                    "time)")
 
 
 # class to represent column

--- a/code/MicroDataTeachingVars.py
+++ b/code/MicroDataTeachingVars.py
@@ -229,29 +229,30 @@ class SocialGradeOptions(OptionEnum):
 
 # class to represent column
 class Column:
-    def __init__(self, values, type):
-        self.values = values
+    def __init__(self, options, type):
+        self.options = options
+        self.values = None if options is None else options.keys()
         self.type = type
 
 # map header to column values
 colMap = {"Person ID" : Column(None, int), # set to None to allow any unique id, CHANGE ?
-          "Region" : Column(RegionOptions.keys(), object),
-          "Residence Type" : Column(ResidenceOptions.keys(), pd.StringDtype()),
-          "Family Composition" : Column(FamilyCompositionOptions.keys(), int),
-          "Population Base" : Column(PopulationBaseOptions.keys(), int),
-          "Sex" : Column(SexOptions.keys(), int),
-          "Age" : Column(AgeOptions.keys(), int),
-          "Marital Status" : Column(MaritalStatusOptions.keys(), int),
-          "Student": Column(StudentOptions.keys(), int),
-          "Country of Birth" : Column(CountryOfBirthOptions.keys(), int),
-          "Health" : Column(HealthOptions.keys(), int),
-          "Ethnic Group" : Column(EthnicityOptions.keys(), int),
-          "Religion" : Column(ReligionOptions.keys(), int),
-          "Economic Activity" : Column(EconomicActivityOptions.keys(), int),
-          "Occupation" : Column(OccupationOptions.keys(), int),
-          "Industry" : Column(IndustryOptions.keys(), int),
-          "Hours worked per week" : Column(HoursWorkedPerWeekOptions.keys(), int),
-          "Approximated Social Grade" : Column(SocialGradeOptions.keys(), int)
+          "Region" : Column(RegionOptions, object),
+          "Residence Type" : Column(ResidenceOptions, pd.StringDtype()),
+          "Family Composition" : Column(FamilyCompositionOptions, int),
+          "Population Base" : Column(PopulationBaseOptions, int),
+          "Sex" : Column(SexOptions, int),
+          "Age" : Column(AgeOptions, int),
+          "Marital Status" : Column(MaritalStatusOptions, int),
+          "Student": Column(StudentOptions, int),
+          "Country of Birth" : Column(CountryOfBirthOptions, int),
+          "Health" : Column(HealthOptions, int),
+          "Ethnic Group" : Column(EthnicityOptions, int),
+          "Religion" : Column(ReligionOptions, int),
+          "Economic Activity" : Column(EconomicActivityOptions, int),
+          "Occupation" : Column(OccupationOptions, int),
+          "Industry" : Column(IndustryOptions, int),
+          "Hours worked per week" : Column(HoursWorkedPerWeekOptions, int),
+          "Approximated Social Grade" : Column(SocialGradeOptions, int)
           }
 
 # compare economic activity to occupation, student status, etc. to find discrepancies

--- a/code/MicroDataTeachingVars.py
+++ b/code/MicroDataTeachingVars.py
@@ -5,36 +5,221 @@ TO DO:
 Map values to descriptions/documentation of meanings
 '''
 import pandas as pd
+from enum import Enum
+from enum import IntEnum
 
 csvPath = "data/census2011.csv"
 
-# value options from pdf
-regions = { "E12000001" : "North East",
-            "E12000002" : "North West",
-            "E12000003" : "Yorkshire and the Humber",
-            "E12000004" : "East Midlands",
-            "E12000005" : "West Midlands",
-            "E12000006" : "East of England",
-            "E12000007" : "London",
-            "E12000008" : "South East",
-            "E12000009" : "South West",
-            "W92000004" : "Wales"}
-residences = ["H","C"]
-familyComp = [*range(1,7), -9]
-popBase = [*range(1,4)]
-sexes = [*range(1,3)]
-ages = [*range(1,9)]
-maritalStat = [*range(1,6)]
-studying = [*range(1,3)] # Boolean ?
-birthCountry = [*range(1,3), -9]
-healthStat = [*range(1,6), -9]
-ethnicity = [*range(1,6), -9]
-religion = [*range(1,10), -9]
-econAct = [*range(1,10), -9]
-job = [*range(1,10), -9]
-industry = [*range(1,13), -9]
-hrs = [*range(1,5), -9]
-socialGr = [*range(1,5), -9]
+class OptionEnum(Enum):
+    @classmethod
+    def parse(cls, encoded):
+        """Parses the encoded key into a enum variant"""
+        for m in cls:
+            if encoded == m.value[0]:
+                return m
+        raise KeyError(str(encoded) + " is not a valid key for " + str(cls))
+
+    @classmethod
+    def keys(cls):
+        """Returns a list of the valid keys for this option"""
+        return [m.value[0] for m in cls]
+
+    def __str__(self):
+        """Returns a human readable description of what this enum signified"""
+        return self.value[1]
+
+    def __repr__(self):
+        """Returns a representation of this enum with both value and type information"""
+        return f"<{self.__class__.__name__}: {self.value[1]}>" 
+
+
+class RegionOptions(OptionEnum):
+    NORTH_EAST    = ("E12000001", "North East")
+    NORTH_WEST    = ("E12000002", "North West")
+    YORKSHIRE     = ("E12000003", "Yorkshire and the Humber")
+    EAST_MIDLANDS = ("E12000004", "East Midlands")
+    WEST_MIDLANDS = ("E12000005", "West Midlands")
+    EAST_ENGLAND  = ("E12000006", "East of England")
+    LONDON        = ("E12000007", "London")
+    SOUTH_EAST    = ("E12000008", "South East")
+    SOUTH_WEST    = ("E12000009", "South West")
+    WALES         = ("W92000004", "Wales")
+
+
+class ResidenceOptions(OptionEnum):
+    """What kind of residence they live in """
+    COMMUNAL =     ("C", "Resident in a communal establishment")
+    NOT_COMMUNAL = ("H", "Not resident in a communal establishment")
+
+
+class FamilyCompositionOptions(OptionEnum):
+    NOT_IN_FAMILY = (1, "Not in a family")
+    MARRIED       = (2, "Married/same-sex civil partnership couple family")
+    COHABITING    = (3, "Cohabiting couple family")
+    LONE_FATHER   = (4, "Lone parent family (male head)")
+    LONE_MOTHER   = (5, "Lone parent family (female head)")
+    OTHER         = (6, "Other related family")
+    NO_CODE       = (-9,"No code required (Resident of communal establishment, \
+                         students or schoolchildren living away during \
+                         term-time, or a short-term resident")
+
+
+class PopulationBaseOptions(OptionEnum):
+    USUAL_RESIDENT      = (1, "Usual resident")
+    STUDENT_AWAY        = (2, "Student living away from home during term-time")
+    SHORT_TERM_RESIDENT = (3, "Short-term resident")
+
+
+class SexOptions(OptionEnum):
+    MALE   = (1, "Male")
+    FEMALE = (2, "Female")
+
+
+class AgeOptions(OptionEnum):
+    UNDER_16      = (1, "0-15")
+    FROM_16_TO_24 = (2, "16-24")
+    FROM_25_TO_34 = (3, "25-34")
+    FROM_35_TO_44 = (4, "35-44")
+    FROM_45_TO_54 = (5, "45-54")
+    FROM_55_TO_64 = (6, "55-64")
+    FROM_65_TO_74 = (7, "65-74")
+    OVER_75       = (8, "75+")
+
+
+class MaritalStatusOptions(OptionEnum):
+    SINGLE    = (1, "Single (never married or never registered in a \
+                     same-sex civil partnership)")
+    MARRIED   = (2, "Married or in a registered same-sex civil partnership")
+    SEPARATED = (3, "Separated but still legally marrried or seperated \
+                     but still legally in a same-sex civil partnership")
+    DIVORCED  = (4, "Divorced or formely in a same-sex civil partnership \
+                     which is now legally dissolved")
+    WIDOWED   = (5, "Widowed or surviving partner from a same-sex \
+                     civil partnership")
+
+
+class StudentOptions(OptionEnum):
+    YES = (1, "Yes")
+    NO  = (2, "No")
+
+
+class CountryOfBirthOptions(OptionEnum):
+    UK      = (1, "UK")
+    NON_UK  = (2, "Non UK")
+    NO_CODE = (-9,"No Code required (Students or schoolchildren living away \
+                   during term-time") 
+
+
+class HealthOptions(OptionEnum):
+    VERY_GOOD = (1, "Very good health")
+    GOOD      = (2, "Good health")
+    FAIR      = (3, "Fair health")
+    BAD       = (4, "Bad health")
+    VERY_BAD  = (5, "Very bad health")
+    NO_CODE   = (-9,"No code required (Students or schoolchildren living away \
+                     during term-time")
+
+
+class EthnicityOptions(OptionEnum):
+    WHITE   = (1, "White")
+    MIXED   = (2, "Mixed")
+    ASIAN   = (3, "Asian or Asian British")
+    BLACK   = (4, "Black or Black British")
+    OTHER   = (5, "Chinese or Other ethnic group")
+    NO_CODE = (-9,"No code required (Not resident in England or Wales, \
+                   students or schoolchildren living away during term time")
+
+class ReligionOptions(OptionEnum):
+    NONE       = (1, "No religion")
+    CHRISTIAN  = (2, "Christian")
+    BUDDHIST   = (3, "Buddhist")
+    HINDU      = (4, "Hindu")
+    JEWISH     = (5, "Jewish")
+    MUSLIM     = (6, "Muslim")
+    SIKH       = (7, "Sikh")
+    OTHER      = (8, "Other religion")
+    NOT_STATED = (9, "Not stated")
+    NO_CODE    = (-9,"No code required (Not resident in England or \
+                      Wales, students or schoolchildren living away \
+                      during term-time)")
+
+
+class EconomicActivityOptions(OptionEnum):
+    EMPLOYEE          = (1, "Economically active: Employee")
+    SELF_EMPLOYED     = (2, "Economically active: Self-employed")
+    UNEMPLOYED        = (3, "Economically active: Unemployed")
+    FULL_TIME_STUDENT = (4, "Economically active: Full-time student")
+    RETIRED           = (5, "Economically inactive: Retired")
+    STUDENT_INACTIVE  = (6, "Economically inactive: Student")
+    CARING            = (7, "Economically inactive: Looking after home or family")
+    SICK_OR_DISABLED  = (8, "Economically inactive: Long-term sick or disabled")
+    OTHER             = (9, "Economically inactive: Other")
+    NO_CODE           = (-9,"No code required (Aged under 16 or students \
+                             or schoolchildren living away during term-time)")
+
+
+class OccupationOptions(OptionEnum):
+    MANAGER                = (1, "Managers, Directors and Senior Officials")
+    PROFESSIONAL           = (2, "Professional Occupations")
+    ASSOCIATE_OR_TECHNICAL = (3, "Associate Professional and Technical Occupations")
+    ADMINISTRATIVE         = (4, "Administrative and Secretarial Occupations")
+    SKILLED_TRADES         = (5, "Skilled Trades Occupations")
+    CARING_SERVICE         = (6, "Caring, Leisure and Other Service Occupations")
+    SALES_SERVICE          = (7, "Sales and Customer Service Occupations")
+    PLANT_OPERATIVE        = (8, "Process, Plant and Machine Operatives")
+    ELEMENTARY             = (9, "Elementary Occupations")
+    NO_CODE                = (-9,"No code required (People aged under 16, \
+                                  people who have never worked and students or \
+                                  schoolchildren living away during term-time)")
+
+
+class IndustryOptions(OptionEnum):
+    AGRICULTURE                 = (1, "Agriculture, forestry and fishing")
+    ESSENTIALS                  = (2, "Mining and quarrying; Manufacturing; \
+                                       Electricity, gas, steam and air conditioning \
+                                       system; Water supply")
+    CONSTRUCTION                = (3, "Construction")
+    TRADE_AND_MOTOR             = (4, "Wholesale and retail trade; Repair of motor \
+                                       vehicles and motorcycles")
+    ACCOMODATION_AND_FOOD       = (5, "Accomodation and food service activities")
+    TRANSPORT_AND_COMMUNICATION = (6, "Transport and storage; \
+                                       Information and communication")
+    FINANCIAL                   = (7, "Financial and insurance activities; Intermediation")
+    REAL_ESTATE_TECHNICAL_ADMIN = (8, "Real estate activities; Professional, \
+                                       scientific and technical activities; \
+                                       Administrative and \
+                                       support service activities")
+    EDUCATION                   = (9, "Education")
+    HEALTH_AND_SOCIAL_WORK      = (10,"Human health and social work activities")
+    PUBLIC_ADMIN_DEFENSE_SOCIAL = (11,"Public administration and defence; \
+                                       compulsory social security")
+    OTHER                       = (12,"Other community, social and personal \
+                                       service activities; Private households \
+                                       employing domestic staff; Extra-territorial \
+                                       organisations and bodies")
+    NO_CODE                     = (-9,"No code required (People aged under 16, \
+                                       people who have never worked, and students or \
+                                       schoolchildren living away during term-time)")
+
+class HoursWorkedPerWeekOptions(OptionEnum):
+    PART_TIME_LOW  = (1, "Part-time: 15 or less hours worked")
+    PART_TIME_HIGH = (2, "Part-time: 16 to 30 hours worked")
+    FULL_TIME_LOW  = (3, "Full-time: 31 to 48 hours worked")
+    FULL_TIME_HIGH = (4, "Full-time: 49 or more hours worked")
+    NO_CODE        = (-9,"No code required (People aged under 16, \
+                          people not working, and students or schoolchildren \
+                          living away during term-time)")
+
+class SocialGradeOptions(OptionEnum):
+    AB = (1, "AB")
+    C1 = (2, "C1")
+    C2 = (3, "C2")
+    DE = (4, "DE")
+    NO_CODE = (-9, "No code required (People aged under 16, \
+                    people resident in communal establishments, and \
+                    students or schoolchildren living away during term- \
+                    time)")
+
 
 # class to represent column
 class Column:
@@ -44,23 +229,23 @@ class Column:
 
 # map header to column values
 colMap = {"Person ID" : Column(None, int), # set to None to allow any unique id, CHANGE ?
-          "Region" : Column(regions, object),
-          "Residence Type" : Column(residences, pd.StringDtype()),
-          "Family Composition" : Column(familyComp, int),
-          "Population Base" : Column(popBase, int),
-          "Sex" : Column(sexes, int),
-          "Age" : Column(ages, int),
-          "Marital Status" : Column(maritalStat, int),
-          "Student": Column(studying, int),
-          "Country of Birth" : Column(birthCountry, int),
-          "Health" : Column(healthStat, int),
-          "Ethnic Group" : Column(ethnicity, int),
-          "Religion" : Column(religion, int),
-          "Economic Activity" : Column(econAct, int),
-          "Occupation" : Column(job, int),
-          "Industry" : Column(industry, int),
-          "Hours worked per week" : Column(hrs, int),
-          "Approximated Social Grade" : Column(socialGr, int)
+          "Region" : Column(RegionOptions.keys(), object),
+          "Residence Type" : Column(ResidenceOptions.keys(), pd.StringDtype()),
+          "Family Composition" : Column(FamilyCompositionOptions.keys(), int),
+          "Population Base" : Column(PopulationBaseOptions.keys(), int),
+          "Sex" : Column(SexOptions.keys(), int),
+          "Age" : Column(AgeOptions.keys(), int),
+          "Marital Status" : Column(MaritalStatusOptions.keys(), int),
+          "Student": Column(StudentOptions.keys(), int),
+          "Country of Birth" : Column(CountryOfBirthOptions.keys(), int),
+          "Health" : Column(HealthOptions.keys(), int),
+          "Ethnic Group" : Column(EthnicityOptions.keys(), int),
+          "Religion" : Column(ReligionOptions.keys(), int),
+          "Economic Activity" : Column(EconomicActivityOptions.keys(), int),
+          "Occupation" : Column(OccupationOptions.keys(), int),
+          "Industry" : Column(IndustryOptions.keys(), int),
+          "Hours worked per week" : Column(HoursWorkedPerWeekOptions.keys(), int),
+          "Approximated Social Grade" : Column(SocialGradeOptions.keys(), int)
           }
 
 # compare economic activity to occupation, student status, etc. to find discrepancies

--- a/code/MicroDataTeachingVarsTest.py
+++ b/code/MicroDataTeachingVarsTest.py
@@ -8,12 +8,18 @@ class TestExampleMicroData(unittest.TestCase):
 
     # Helper functions
     def check_valid(self, values, permitted):
+        if permitted is None:
+            return True
         s = pd.Series(values)
-        self.assertTrue(col_valid(s, permitted))
+        if col_valid(s, permitted.keys()):
+            return True
+        for v in values:
+            if not col_valid(pd.Series(v), permitted.keys()):
+                self.fail(f"Expected {v} be valid, but it was not (permitted: {permitted.keys()})")
 
     def check_invalid_single(self, value, permitted):
         s = pd.Series([value])
-        self.assertFalse(col_valid(s, permitted))
+        self.assertFalse(col_valid(s, permitted.keys()))
 
     # Student ID
     def test_valid_student_id(self):
@@ -35,142 +41,141 @@ class TestExampleMicroData(unittest.TestCase):
             "E12000009",
             "W92000004"
         ]
-        self.check_valid(valid_regions, md.regions)
+        self.check_valid(valid_regions, md.RegionOptions)
 
     def test_invalid_regions(self):
-        self.check_invalid_single("S12000001", md.regions)
-        self.check_invalid_single(60, md.regions)
+        self.check_invalid_single("S12000001", md.RegionOptions)
+        self.check_invalid_single(60, md.RegionOptions)
 
     # Residence types
     def test_residence_type(self):
-        self.check_valid(["H", "C"], md.residences)
+        self.check_valid(["H", "C"], md.ResidenceOptions)
 
     def test_invalid_residence_type(self):
-        self.check_invalid_single("O", md.residences)
-        self.check_invalid_single(0, md.residences)
+        self.check_invalid_single("O", md.ResidenceOptions)
+        self.check_invalid_single(0, md.ResidenceOptions)
 
     # Family Composition
     def test_family_composition_valid(self):
-        self.check_valid([3,2,1,4,5,6,-9], md.familyComp)
+        self.check_valid([3,2,1,4,5,6,-9], md.FamilyCompositionOptions)
 
     def test_family_composition_invalid(self):
-        self.check_invalid_single(0, md.familyComp)
-        self.check_invalid_single(-1, md.familyComp)
+        self.check_invalid_single(0, md.FamilyCompositionOptions)
+        self.check_invalid_single(-1, md.FamilyCompositionOptions)
 
     # Population base
     def test_population_base_valid(self):
-        s = pd.Series([1, 2, 3])
-        self.assertTrue(col_valid(s, md.popBase))
+        self.check_valid([1, 2, 3], md.PopulationBaseOptions)
 
     def test_population_base_invalid(self):
-        self.check_invalid_single(0, md.popBase)
-        self.check_invalid_single(-1, md.popBase)
-        self.check_invalid_single(-9, md.popBase)
+        self.check_invalid_single(0, md.PopulationBaseOptions)
+        self.check_invalid_single(-1, md.PopulationBaseOptions)
+        self.check_invalid_single(-9, md.PopulationBaseOptions)
 
     # Sex
     def test_sex_valid(self):
-        self.check_valid([1, 2], md.sexes)
+        self.check_valid([1, 2], md.SexOptions)
 
     def test_sex_invalid_3(self):
-        self.check_invalid_single(0, md.sexes)
-        self.check_invalid_single(3, md.sexes)
-        self.check_invalid_single(-9, md.sexes)
+        self.check_invalid_single(0, md.SexOptions)
+        self.check_invalid_single(3, md.SexOptions)
+        self.check_invalid_single(-9, md.SexOptions)
 
     # Age
     def test_age_valid(self):
-        self.check_valid([1, 2, 3, 4, 5, 6, 7, 8], md.ages)
+        self.check_valid([1, 2, 3, 4, 5, 6, 7, 8], md.AgeOptions)
 
     def test_age_invalid(self):
-        self.check_invalid_single(0, md.ages)
-        self.check_invalid_single(9, md.ages)
-        self.check_invalid_single(-9, md.ages)
+        self.check_invalid_single(0, md.AgeOptions)
+        self.check_invalid_single(9, md.AgeOptions)
+        self.check_invalid_single(-9, md.AgeOptions)
 
     # Marital Status
     def test_marital_status_valid(self):
-        self.check_valid([1,2,3,4,5], md.maritalStat)
+        self.check_valid([1,2,3,4,5], md.MaritalStatusOptions)
 
     def test_marital_status_invalid_zero(self):
-        self.check_invalid_single(0, md.maritalStat)
-        self.check_invalid_single(6, md.maritalStat)
-        self.check_invalid_single(-9, md.maritalStat)
+        self.check_invalid_single(0, md.MaritalStatusOptions)
+        self.check_invalid_single(6, md.MaritalStatusOptions)
+        self.check_invalid_single(-9, md.MaritalStatusOptions)
 
     # Student
     def test_student_valid(self):
-        self.check_valid([1, 2], md.studying)
+        self.check_valid([1, 2], md.StudentOptions)
 
     def test_student_invalid_zero(self):
-        self.check_invalid_single(0, md.studying)
-        self.check_invalid_single(3, md.studying)
-        self.check_invalid_single(-9, md.studying)
+        self.check_invalid_single(0, md.StudentOptions)
+        self.check_invalid_single(3, md.StudentOptions)
+        self.check_invalid_single(-9, md.StudentOptions)
 
     # Country of birth
     def test_birth_country_valid(self):
-        self.check_valid([1, 2, -9], md.birthCountry)
+        self.check_valid([1, 2, -9], md.CountryOfBirthOptions)
 
     def test_birth_country_invalid_zero(self):
-        self.check_invalid_single(0, md.birthCountry)
-        self.check_invalid_single(3, md.birthCountry)
+        self.check_invalid_single(0, md.CountryOfBirthOptions)
+        self.check_invalid_single(3, md.CountryOfBirthOptions)
 
     # Health
     def test_health_valid(self):
-        self.check_valid([1, 2, 3, 4, 5, -9], md.healthStat)
+        self.check_valid([1, 2, 3, 4, 5, -9], md.HealthOptions)
 
     def test_health_invalid(self):
-        self.check_invalid_single(0, md.healthStat)
-        self.check_invalid_single(6, md.healthStat)
+        self.check_invalid_single(0, md.HealthOptions)
+        self.check_invalid_single(6, md.HealthOptions)
 
     # Ethnic Group
     def test_ethnicity_valid(self):
-        self.check_valid([1,2,3,4,5,-9], md.ethnicity)
+        self.check_valid([1,2,3,4,5,-9], md.EthnicityOptions)
 
     def test_ethnicity_invalid(self):
-        self.check_invalid_single(0, md.ethnicity)
-        self.check_invalid_single(6, md.ethnicity)
+        self.check_invalid_single(0, md.EthnicityOptions)
+        self.check_invalid_single(6, md.EthnicityOptions)
 
     # Religion
     def test_religion_valid(self):
-        self.check_valid([1,2,3,4,5,6,7,8,9,-9], md.religion)
+        self.check_valid([1,2,3,4,5,6,7,8,9,-9], md.ReligionOptions)
 
     def test_religion_invalid(self):
-        self.check_invalid_single(0, md.religion)
-        self.check_invalid_single(10, md.religion)
+        self.check_invalid_single(0, md.ReligionOptions)
+        self.check_invalid_single(10, md.ReligionOptions)
 
     # Economic activity
     def test_economic_activity_valid(self):
-        self.check_valid([1,2,3,4,5,6,7,8,9,-9], md.econAct)
+        self.check_valid([1,2,3,4,5,6,7,8,9,-9], md.EconomicActivityOptions)
 
     def test_economic_activity_invalid(self):
-        self.check_invalid_single(0, md.econAct)
-        self.check_invalid_single(10, md.econAct)
+        self.check_invalid_single(0, md.EconomicActivityOptions)
+        self.check_invalid_single(10, md.EconomicActivityOptions)
 
     # Occupation
     def test_occupation_valid(self):
-        self.check_valid([1,2,3,4,5,6,7,8,9,-9], md.job)
+        self.check_valid([1,2,3,4,5,6,7,8,9,-9], md.OccupationOptions)
 
     def test_occupation_invalid(self):
-        self.check_invalid_single(0, md.job)
-        self.check_invalid_single(10, md.job)
+        self.check_invalid_single(0, md.OccupationOptions)
+        self.check_invalid_single(10, md.OccupationOptions)
 
     # Industry
     def test_industry_valid(self):
-        self.check_valid([1,2,3,4,5,6,7,8,9,10,11,12,-9], md.industry)
+        self.check_valid([1,2,3,4,5,6,7,8,9,10,11,12,-9], md.IndustryOptions)
 
     def test_industry_invalid(self):
-        self.check_invalid_single(0, md.industry)
-        self.check_invalid_single(13, md.industry)
+        self.check_invalid_single(0, md.IndustryOptions)
+        self.check_invalid_single(13, md.IndustryOptions)
 
     # Hours worked per week
     def test_hours_valid(self):
-        self.check_valid([1,2,3,4,-9], md.hrs)
+        self.check_valid([1,2,3,4,-9], md.HoursWorkedPerWeekOptions)
 
     def test_hours_invalid(self):
-        self.check_invalid_single(0, md.hrs)
-        self.check_invalid_single(5, md.hrs)
+        self.check_invalid_single(0, md.HoursWorkedPerWeekOptions)
+        self.check_invalid_single(5, md.HoursWorkedPerWeekOptions)
 
     # Approximated social grade
     def test_social_grade_valid(self):
-        self.check_valid([1,2,3,4,-9], md.socialGr)
+        self.check_valid([1,2,3,4,-9], md.SocialGradeOptions)
 
     def test_social_grade_invalid(self):
-        self.check_invalid_single(0, md.socialGr)
-        self.check_invalid_single(5, md.socialGr)
+        self.check_invalid_single(0, md.SocialGradeOptions)
+        self.check_invalid_single(5, md.SocialGradeOptions)

--- a/code/consistency.py
+++ b/code/consistency.py
@@ -35,7 +35,7 @@ def main():
 def cleanDataFrame(df):    
     # appropriate values
     if hasProblemValue(df):
-        dropRows(findProblemRows(df))
+        dropRows(df, findProblemRows(df))
     # appropriate types
     problemColumns = checkTypes(df)
     reTypeCols(df, problemColumns)
@@ -76,12 +76,16 @@ def checkTypes(df):
 def findProblemRows(df):
     print("Finding rows with problem values...")
     problems = []
-    for index, row, in df.iterrows():
-        for col in df:
-            if colMap.get(col).values is not None and not df[col][index] in colMap.get(col).values:
-                #colValidity(df[col][index], colMap.get(col).values):
-                print("Discrepancy of value in row ", index, "column", col)
-                problems.append(index)
+    for col_name in df:
+        print("Column:", col_name)
+        col = colMap[col_name]
+        if col.values is None:
+            continue
+        values_good = df[col_name].isin(col.values)
+        bad_values = values_good[~values_good].index
+        if len(bad_values) != 0:
+            print("Discrepancies in column ", col_name, "-", bad_values)
+            return list(bad_values)
     print("Problem finding finished.")
     return problems
 

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+# Use the first argument as the port number if given
+port=${1:-8888}
 source code/.venv/bin/activate && \
-jupyter lab notebooks/census2011.ipynb
+jupyter lab notebooks/census2011.ipynb --port "$port"


### PR DESCRIPTION
I think this is a good way to make it easy to describe a data set - it can be generalised to any data set which makes our approach very practical.
I've fit it into the existing system, but it also provides descriptions:


### Examples of things you can now do:

The definition:
```python
class CountryOfBirthOptions(OptionEnum):
    UK      = (1, "UK")
    NON_UK  = (2, "Non UK")
    NO_CODE = (-9,"No Code required (Students or schoolchildren living away "
                   "during term-time")
```

#### List all available values ####
```console
>>> list(md.CountryOfBirthOptions)
[<CountryOfBirthOptions: 1 -> UK>, <CountryOfBirthOptions: 2 -> NON_UK>, <CountryOfBirthOptions: -9 -> NO_CODE>]
```

```console
>>> [str(x) for x in md.CountryOfBirthOptions]
['UK', 'Non UK', 'No Code required (Students or schoolchildren living away during term-time']
```